### PR TITLE
feat: Make the Bundler version configurable

### DIFF
--- a/example/.dockerdev/Dockerfile
+++ b/example/.dockerdev/Dockerfile
@@ -66,9 +66,10 @@ ENV BUNDLE_APP_CONFIG=.bundle
 # Uncomment this line if you want to run binstubs without prefixing with `bin/` or `bundle exec`
 # ENV PATH /app/bin:$PATH
 
-# Upgrade RubyGems and install the latest Bundler version
+# Upgrade RubyGems and install the configured Bundler version
+ARG BUNDLER_VERSION
 RUN gem update --system && \
-    gem install bundler
+    gem install bundler -v $BUNDLER_VERSION
 
 # Create a directory for the app code
 RUN mkdir -p /app

--- a/example/.dockerdev/compose.yml
+++ b/example/.dockerdev/compose.yml
@@ -6,6 +6,7 @@ x-app: &app
       PG_MAJOR: '14'
       NODE_MAJOR: '16'
       YARN_VERSION: '1.22.17'
+      BUNDLER_VERSION: '2.3.9'
   image: example-dev:1.0.0
   environment: &env
     NODE_ENV: ${NODE_ENV:-development}


### PR DESCRIPTION
Heroku does not always use the latest version of Bundler, but sometimes
uses older versions to avoid some bugs:

https://github.com/heroku/heroku-buildpack-ruby/commit/d42226c1dc0dfbc123b1facaeae276cf3d2689a6

For the local development environment to match the setup on Heroku, the
Bundler version needs to be configurable.