### PR TITLE
fix: Disable clustered mode for Puma

### DIFF
--- a/example/.dockerdev/compose.yml
+++ b/example/.dockerdev/compose.yml
@@ -34,7 +34,7 @@ x-backend: &backend
     DATABASE_URL: postgres://postgres:postgres@postgres:5432
     WEBPACKER_DEV_SERVER_HOST: webpacker
     MALLOC_ARENA_MAX: 2
-    WEB_CONCURRENCY: ${WEB_CONCURRENCY:-1}
+    WEB_CONCURRENCY: ${WEB_CONCURRENCY:-0}
     BOOTSNAP_CACHE_DIR: /usr/local/bundle/_bootsnap
     XDG_DATA_HOME: /app/tmp/caches
     YARN_CACHE_FOLDER: /app/node_modules/.yarn-cache


### PR DESCRIPTION
Puma is not intended to be used in clustered mode for local development
and emits a warning on start if it is configured to use one worker
in clustered mode (instead of 0 workers, which disables clustered mode).