### PR TITLE
fix: Use the current default branch in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
This repository uses `main` as the default git branch, not `master`
anymore. So CI should build `main`.