### PR TITLE
Don't fail if couldn't detect Ruby version from Gemfile.lock

### DIFF
--- a/generator/_ruby_details.rb
+++ b/generator/_ruby_details.rb
@@ -7,7 +7,7 @@ begin
   if File.file?("Gemfile.lock")
     bundler_parser = Bundler::LockfileParser.new(Bundler.read_file("Gemfile.lock"))
     gemspecs =  Hash[bundler_parser.specs.map { |spec| [spec.name, spec.version] }]
-    maybe_ruby_version = bundler_parser.ruby_version.match(/ruby (\d+\.\d+\.\d+)./i)&.[](1)
+    maybe_ruby_version = bundler_parser.ruby_version&.match(/ruby (\d+\.\d+\.\d+)./i)&.[](1)
   end
 
   begin


### PR DESCRIPTION
Sometimes `Bundler::LockfileParser#ruby_version` is `nil` ¯\_(ツ)_/¯

Found this today on Ruby 2.6.3 and Bundler 2.2.17