### PR TITLE
Fixed typo `/user/local` -> `/usr/local`

### DIFF
--- a/example/.dockerdev/compose.yml
+++ b/example/.dockerdev/compose.yml
@@ -73,9 +73,9 @@ services:
     volumes:
       - .psqlrc:/root/.psqlrc:ro
       - postgres:/var/lib/postgresql/data
-      - history:/user/local/hist
+      - history:/usr/local/hist
     environment:
-      PSQL_HISTFILE: /user/local/hist/.psql_history
+      PSQL_HISTFILE: /usr/local/hist/.psql_history
       POSTGRES_PASSWORD: postgres
     ports:
       - 5432

--- a/generator/compose.yml.tt
+++ b/generator/compose.yml.tt
@@ -115,9 +115,9 @@ services:
     volumes:
       - .psqlrc:/root/.psqlrc:ro
       - postgres:/var/lib/postgresql/data
-      - history:/user/local/hist
+      - history:/usr/local/hist
     environment:
-      PSQL_HISTFILE: /user/local/hist/.psql_history
+      PSQL_HISTFILE: /usr/local/hist/.psql_history
       POSTGRES_PASSWORD: postgres
     ports:
       - 5432


### PR DESCRIPTION
The postgres compose part contains the wrong path for the history volume.