### PR TITLE
Upgrade to Debian Bookworm

### DIFF
--- a/example/.dockerdev/Dockerfile
+++ b/example/.dockerdev/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG RUBY_VERSION
-ARG DISTRO_NAME=bullseye
+ARG DISTRO_NAME=bookworm
 
 FROM ruby:$RUBY_VERSION-slim-$DISTRO_NAME
 

--- a/template/Dockerfile.tt
+++ b/template/Dockerfile.tt
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG RUBY_VERSION
-ARG DISTRO_NAME=bullseye
+ARG DISTRO_NAME=bookworm
 
 FROM ruby:$RUBY_VERSION-slim-$DISTRO_NAME
 


### PR DESCRIPTION
Debian Bookworm is the new stable release. It was released on February 10th, 2024.

https://www.debian.org/releases/bookworm/