### PR TITLE
Upgrade to Bundler 2.5.6

### DIFF
--- a/example/.github/workflows/test.yml
+++ b/example/.github/workflows/test.yml
@@ -31,12 +31,12 @@ jobs:
             PG_MAJOR=14
             NODE_MAJOR=16
             YARN_VERSION=1.22.17
-            BUNDLER_VERSION=2.3.6
+            BUNDLER_VERSION=2.5.6
       # Need for local gems installation
       - name: Setup Ruby with Bundler
         uses: ruby/setup-ruby@v1
         with:
-          bundler: 2.3.6
+          bundler: 2.5.6
       - name: Install dip
         run: gem install dip
       - name: Bundle deps


### PR DESCRIPTION
Now that Heroku finally has added support for Bundler 2.5.6, it's safe to use Bundler 2.5.6 as the default version.

https://devcenter.heroku.com/changelog-items/2808